### PR TITLE
Only output model details per guide when an output file is specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ __pycache__
 src/cleanser/build
 post
 posteriors
+
+# VS Code settings
+.vscode/
+
+# STAN compiled files 
+src/cleanser/cs-guide-mixture
+src/cleanser/dc-guide-mixture

--- a/src/cleanser/run.py
+++ b/src/cleanser/run.py
@@ -165,8 +165,8 @@ def run_cli():
             num_warmup=args.num_warmup,
             seed=args.seed,
         )
-
-        configuration.output_samples()
+        if args.so is not None:
+            configuration.output_samples()
         configuration.output_posteriors()
         configuration.output_stats()
 


### PR DESCRIPTION
Skip this step instead of dumping to stdout if no argument is used